### PR TITLE
Changed type of msg for compatibility with Linux >= 3.19

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -130,7 +130,7 @@ int write_vaddr_tcp(void * v, size_t is) {
 	long s;
 
 	struct iovec iov;
-	struct msghdr msg  = { .msg_iov = &iov, .msg_iovlen = 1 };
+	struct user_msghdr msg  = { .msg_iov = &iov, .msg_iovlen = 1 };
 
 	fs = get_fs();
 	set_fs(KERNEL_DS);


### PR DESCRIPTION
Changed type of variable msg from msghdr to user_msghdr in function write_vaddr_tcp to be compatible with Linux Kernel >= 3.19.

See: https://lkml.org/lkml/2014/11/18/862