### PR TITLE
Indicates in documentation that raw format is not supported by Volatility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ insmod ./lime.ko "path=<outfile | tcp:<port>> format=<raw|padded|lime> [dio=<0|1
 path (required):   outfile ~ name of file to write to on local system (SD Card)
                    tcp:port ~ network port to communicate over
         
-format (required): raw ~ concatenates all System RAM ranges
-                   padded ~ pads all non-System RAM ranges with 0s
+format (required): padded ~ pads all non-System RAM ranges with 0s
                    lime ~ each range prepended with fixed-size header containing address space info
+                   raw ~ concatenates all System RAM ranges (warning : original position of dumped memory is likely to be lost)
         
 dio (optional):    1 ~ attempt to enable Direct IO
                    0 ~ default, do not attempt Direct IO

--- a/doc/README.md
+++ b/doc/README.md
@@ -83,9 +83,9 @@ Starting in version 1.1, LiME now supports multiple output formats, including a 
 NOTE: There is a bug in the insmod utility on some Android devices.  Multiple kernel module parameters must be wrapped in quotation marks, otherwise only the first parameter will be parsed.  See sections 4.2 and 4.3 for examples.
 ```
 path          Either a filename to write on the local system (SD Card) or tcp:<port>
-format        raw: Simply concatenates all System RAM ranges. Volatility does not support this format, as memory position information is lost (unless System RAM is in one continuous range starting from physical address 0)
-              padded: Pads all non-System RAM ranges with 0s, starting from physical address 0. Volatility support this format
-              lime: Each range is prepended with a fixed-sized header which contains address space information. Volatility address space developed to support this format
+format        padded: Pads all non-System RAM ranges with 0s, starting from physical address 0.
+              lime: Each range is prepended with a fixed-sized header which contains address space information.
+              raw: Simply concatenates all System RAM ranges. Most memory analysis tools do not support this format, as memory position information is lost (unless System RAM is in one continuous range starting from physical address 0)
 dio           Optional. 1 to enable Direct IO attempt, 0 to disable (default)
 localhostonly Optional. 1 restricts the tcp to only listen on localhost, 0 binds on all interfaces (default)
 timeout       Optional. If it takes longer than the specified  timeout (in milliseconds) to read/write a page

--- a/doc/README.md
+++ b/doc/README.md
@@ -83,8 +83,8 @@ Starting in version 1.1, LiME now supports multiple output formats, including a 
 NOTE: There is a bug in the insmod utility on some Android devices.  Multiple kernel module parameters must be wrapped in quotation marks, otherwise only the first parameter will be parsed.  See sections 4.2 and 4.3 for examples.
 ```
 path          Either a filename to write on the local system (SD Card) or tcp:<port>
-format        raw: Simply concatenates all System RAM ranges
-              padded: Pads all non-System RAM ranges with 0s, starting from physical address 0
+format        raw: Simply concatenates all System RAM ranges. Volatility does not support this format, as memory position information is lost (unless System RAM is in one continuous range starting from physical address 0)
+              padded: Pads all non-System RAM ranges with 0s, starting from physical address 0. Volatility support this format
               lime: Each range is prepended with a fixed-sized header which contains address space information. Volatility address space developed to support this format
 dio           Optional. 1 to enable Direct IO attempt, 0 to disable (default)
 localhostonly Optional. 1 restricts the tcp to only listen on localhost, 0 binds on all interfaces (default)


### PR DESCRIPTION
Hi,
I modified the documentation a bit to add a warning on "raw" format. To my point of view, this should not be the first presented in the list as it is the only one not exploitable by Volatility (or other tools). The non-System RAM ranges being skipped, it becomes very difficult to know where each byte of the dump was originally in the physical memory.
(However, by searching for "BIOS-e820 memory map" kernel messages in dumped memory, it is possible to infer the original position of memory and reconstruct a "padded" dump, but it is painful and uselessly time consuming)

It might be useful for people that use this tool in situations where taking a second memory dump (after realizing their mistake) is not possible :)