### PR TITLE
Disable the timeout option by default to avoid mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ dio (optional):    1 ~ attempt to enable Direct IO
 localhostonly (optional):  1 ~ restricts the tcp to only listen on localhost,
                            0 ~ binds on all interfaces (default)
 
-timeout (optional): 1000 ~ max amount of milliseconds tolerated to read a page (default).
+timeout (optional):    n ~ max amount of milliseconds tolerated to read a page.
                            If a page exceeds the timeout all the memory region are skipped.
-                       0 ~ disable the timeout so the slow region will be acquired.
+                       0 ~ disable the timeout so the slow region will be acquired (default).
 
                            This feature is only available on kernel versions >= 2.6.35. 
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -89,8 +89,8 @@ format        padded: Pads all non-System RAM ranges with 0s, starting from phys
 dio           Optional. 1 to enable Direct IO attempt, 0 to disable (default)
 localhostonly Optional. 1 restricts the tcp to only listen on localhost, 0 binds on all interfaces (default)
 timeout       Optional. If it takes longer than the specified  timeout (in milliseconds) to read/write a page
-              of memory then the range is assumed to be bad and is skipped.  To disable this set timeout to 0.
-              The default setting is 1000 (1 second).
+              of memory then the range is assumed to be bad and is skipped.  To enable this set timeout to any positive value.
+              The default setting is 0 (disabled).
 ```
 
 ### Acquisition of Memory over TCP <a name="TCP"/>

--- a/src/main.c
+++ b/src/main.c
@@ -59,7 +59,7 @@ module_param(format, charp, S_IRUGO);
 module_param(localhostonly, int, S_IRUGO);
 
 #ifdef LIME_SUPPORTS_TIMING
-long timeout = 1000;
+long timeout = 0;
 module_param(timeout, long, S_IRUGO);
 #endif
 


### PR DESCRIPTION
When the timeout condition triggers, the error is completely silent (unless LiME has been compiled in DEBUG mode).
This could lead to incomplete memory dump without LiME user knowing it.
This commit disables the timeout option by default, to prefer soundness over performance, especially in cases where it is impossible to take a second memory dump after realizing the memory dump is incomplete (e.g. in forensics context, where the target machine has to be rebooted after the memory snapshot has been taken).