### PR TITLE
KDIR support (headers outside standard location)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,26 +25,28 @@ lime-objs := tcp.o disk.o main.o
 
 KVER ?= $(shell uname -r)
 
+KDIR ?= /lib/modules/$(KVER)/build
+
 PWD := $(shell pwd)
 
 .PHONY: modules modules_install clean distclean debug
 
 default:
-	$(MAKE) -C /lib/modules/$(KVER)/build M="$(PWD)" modules
+	$(MAKE) -C $(KDIR) M="$(PWD)" modules
 	strip --strip-unneeded lime.ko
 	mv lime.ko lime-$(KVER).ko
 
 debug:
-	KCFLAGS="-DLIME_DEBUG" $(MAKE) -C /lib/modules/$(KVER)/build M="$(PWD)" modules
+	KCFLAGS="-DLIME_DEBUG" $(MAKE) -C $(KDIR) M="$(PWD)" modules
 	strip --strip-unneeded lime.ko
 	mv lime.ko lime-$(KVER).ko
 
 modules:    main.c disk.c tcp.c lime.h
-	$(MAKE) -C /lib/modules/$(KVER)/build M="$(PWD)" $@
+	$(MAKE) -C $(KDIR) M="$(PWD)" $@
 	strip --strip-unneeded lime.ko
 
 modules_install:    modules
-	$(MAKE) -C /lib/modules/$(KVER)/build M="$(PWD)" $@
+	$(MAKE) -C $(KDIR) M="$(PWD)" $@
 
 clean:
 	rm -f *.o *.mod.c Module.symvers Module.markers modules.order \.*.o.cmd \.*.ko.cmd \.*.o.d


### PR DESCRIPTION
That means you can compile with:
make KDIR="/mnt/lib/kernel-headers-x.x.x/"