### PR TITLE
TCP TIME_WAIT isnt fast enough for bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Acquiring to sdcard
 
 ## Available Digests
 Really LiME will support any digest algorithm that the kernel library can.
+Collecting a digest file when dumping over tcp will require 2 separate connections.
+```
+$ nc localhost 4444 > ram.lime
+$ nc localhost 4444 > ram.sha1
+```
 For a quick reference here is a list of supported digests.
 ### All kernel versions
 ```

--- a/src/hash.c
+++ b/src/hash.c
@@ -198,9 +198,9 @@ static int ldigest_write(void) {
     strcat(path, ".");
     strcat(path, digest);
 
+    // Sleep due to the rapid succession of port bind.
     msleep(4);
     if ((err = setup())) {
-        
         DBG("Setup Error for Digest File");
         cleanup();
     }

--- a/src/hash.c
+++ b/src/hash.c
@@ -198,7 +198,9 @@ static int ldigest_write(void) {
     strcat(path, ".");
     strcat(path, digest);
 
+    msleep(4);
     if ((err = setup())) {
+        
         DBG("Setup Error for Digest File");
         cleanup();
     }

--- a/src/lime.h
+++ b/src/lime.h
@@ -34,6 +34,7 @@
 #include <linux/string.h>
 #include <linux/err.h>
 #include <linux/scatterlist.h>
+#include <linux/delay.h>
 
 #include <net/sock.h>
 #include <net/tcp.h>


### PR DESCRIPTION
Add a very small delay to the second port bind when using digest over tcp

This change fixes and issue where an attempt to bind to a port happened too soon.
The port would have been in TIME_WAIT and in use until released by the kernel.
It usually takes 2ms to release, so we wait for 4ms.
