### PR TITLE
New option for zlib compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,22 @@ LiME utilizes the insmod command to load the module, passing required arguments 
 ```
 insmod ./lime.ko "path=<outfile | tcp:<port>> format=<raw|padded|lime> [digest=<digest>] [dio=<0|1>]"
 
-path (required):   outfile ~ name of file to write to on local system (SD Card)
-                   tcp:port ~ network port to communicate over
+path (required):     outfile ~ name of file to write to on local system (SD Card)
+                     tcp:port ~ network port to communicate over
         
-format (required): padded ~ pads all non-System RAM ranges with 0s
-                   lime ~ each range prepended with fixed-size header containing address space info
-                   raw ~ concatenates all System RAM ranges (warning : original position of dumped memory is likely to be lost)
+format (required):   padded ~ pads all non-System RAM ranges with 0s
+                     lime ~ each range prepended with fixed-size header containing address space info
+                     raw ~ concatenates all System RAM ranges (warning : original position of dumped memory is likely to be lost)
 
-digest (optional): Hash the RAM and provide a .digest file with the sum.
-                   Supports kernel version 2.6.11 and up. See below for
-                   available digest options.
+digest (optional):   Hash the RAM and provide a .digest file with the sum.
+                     Supports kernel version 2.6.11 and up. See below for
+                     available digest options.
 
-dio (optional):    1 ~ attempt to enable Direct IO
-                   0 ~ default, do not attempt Direct IO
+compress (optional): 1 ~ compress output with zlib
+                     0 ~ do not compress (default)
+
+dio (optional):      1 ~ attempt to enable Direct IO
+                     0 ~ do not attempt Direct IO (default)
         
 localhostonly (optional):  1 ~ restricts the tcp to only listen on localhost,
                            0 ~ binds on all interfaces (default)
@@ -89,6 +92,19 @@ sha3-224, sha3-256, sha3-384, sha3-512
 rmd128, rmd160, rmd256, rmd320
 ```
 
+## Compression
+
+Compression can reduce significantly the time required to acquire a memory capture. It can achieve the speedup of 4x over uncompressed transfers with a few memory overhead (~ 24 KB).
+
+The RAM file will be in the zlib format, which is different from the gzip or zip formats. The reason is that the deflate library embedded in the kernel do not support them.
+
+To decompress it you can use [pigz](https://zlib.net/pigz/) or any zlib-compatible library.
+
+```
+$ nc localhost 4444 | unpigz > ram.lime
+```
+
+Note that only the RAM file is compressed. The digest file is not compressed, and the hash value will match the uncompressed data.
 
 ## Presentation <a name="present"/>
 LiME was first presented at Shmoocon 2012 by Joe Sylve.  

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@
 
 
 obj-m := lime.o
-lime-objs := tcp.o disk.o main.o hash.o
+lime-objs := tcp.o disk.o main.o hash.o deflate.o
 
 KVER ?= $(shell uname -r)
 

--- a/src/deflate.c
+++ b/src/deflate.c
@@ -1,0 +1,99 @@
+/*
+ * LiME - Linux Memory Extractor
+ * Copyright (c) 2011-2014 Joe Sylve - 504ENSICS Labs
+ *
+ *
+ * Author:
+ * Joe Sylve       - joe.sylve@gmail.com, @jtsylve
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifdef CONFIG_ZLIB_DEFLATE
+#include <linux/zlib.h>
+
+#include "lime.h"
+
+/* Balance high compression level and memory footprint. */
+#define DEFLATE_WBITS       11  /* 8KB */
+#define DEFLATE_MEMLEVEL    5   /* 12KB */
+
+static struct z_stream_s zstream;
+
+static void *next_out;
+static size_t avail_out;
+
+extern int deflate_begin_stream(void *out, size_t outlen)
+{
+    int size;
+
+    size = zlib_deflate_workspacesize(DEFLATE_WBITS, DEFLATE_MEMLEVEL);
+    zstream.workspace = kzalloc(size, GFP_NOIO);
+    if (!zstream.workspace) {
+        return -ENOMEM;
+    }
+
+    if (zlib_deflateInit2(&zstream, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
+                          DEFLATE_WBITS,
+                          DEFLATE_MEMLEVEL,
+                          Z_DEFAULT_STRATEGY) != Z_OK) {
+        kfree(zstream.workspace);
+        return -EINVAL;
+    }
+
+    next_out = out;
+    avail_out = outlen;
+
+    zstream.next_out = next_out;
+    zstream.avail_out = avail_out;
+
+    return 0;
+}
+
+int deflate_end_stream(void)
+{
+    zlib_deflateEnd(&zstream);
+    kfree(zstream.workspace);
+    return 0;
+}
+
+ssize_t deflate(const void *in, size_t inlen)
+{
+    int flush, ret;
+
+    if (in && inlen > 0)
+        flush = Z_NO_FLUSH;
+    else
+        flush = Z_FINISH;
+
+    if (zstream.avail_out != 0) {
+        zstream.next_in = in;
+        zstream.avail_in = inlen;
+    }
+
+    zstream.next_out = next_out;
+    zstream.avail_out = avail_out;
+
+    ret = zlib_deflate(&zstream, flush);
+
+    if (ret != Z_OK && !(flush == Z_FINISH && ret == Z_STREAM_END)) {
+        DBG("Deflate error: %d", ret);
+        return -EIO;
+    }
+
+    return avail_out - zstream.avail_out;
+}
+
+#endif

--- a/src/hash.c
+++ b/src/hash.c
@@ -170,21 +170,11 @@ final_fail:
 }
 
 int ldigest_write_tcp(void) {
-    int retry;
-    int err = 0;
+    int ret;
 
-    for (retry = 1; retry < 11; retry++) {
-        if ((err = setup_tcp())) {
-            DBG("Socket bind failed. Try: %i/10", retry);
-            cleanup_tcp();
-            msleep(5000);
-        } else {
-            break;
-        }
-    }
-
-    if (err) {
-        DBG("Setup Error for Digest File.");
+    ret = setup_tcp();
+    if (ret < 0) {
+        DBG("Socket bind failed for digest file: %d", ret);
         cleanup_tcp();
         return LIME_DIGEST_FAILED;
     }

--- a/src/lime.h
+++ b/src/lime.h
@@ -34,7 +34,6 @@
 #include <linux/string.h>
 #include <linux/err.h>
 #include <linux/scatterlist.h>
-#include <linux/delay.h>
 
 #include <net/sock.h>
 #include <net/tcp.h>

--- a/src/lime.h
+++ b/src/lime.h
@@ -77,6 +77,10 @@
 #define LIME_SUPPORTS_TIMING
 #endif
 
+#ifdef CONFIG_ZLIB_DEFLATE
+#define LIME_SUPPORTS_DEFLATE
+#endif
+
 //structures
 
 typedef struct {

--- a/src/lime.h
+++ b/src/lime.h
@@ -67,6 +67,12 @@
 #define DBG(fmt, args...) do {} while(0)
 #endif
 
+#define RETRY_IF_INTERRUPTED(f) ({ \
+    ssize_t err; \
+    do { err = f; } while(err == -EAGAIN || err == -EINTR); \
+    err; \
+})
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,35)
 #define LIME_SUPPORTS_TIMING
 #endif

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -112,11 +112,7 @@ int setup_tcp() {
         return r;
     }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)
-    r = kernel_accept(control, &accept, 0, true);
-#else
     r = kernel_accept(control, &accept, 0);
-#endif
 
     if (r < 0) {
         DBG("Error accepting socket");

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -46,11 +46,9 @@ static struct socket *accept;
 
 int setup_tcp() {
     struct sockaddr_in saddr;
-    int r;
+    int r, opt;
 
     mm_segment_t fs;
-
-    int buffsize = PAGE_SIZE;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
     r = sock_create_kern(&init_net, AF_INET, SOCK_STREAM, IPPROTO_TCP, &control);
@@ -79,7 +77,9 @@ int setup_tcp() {
     fs = get_fs();
     set_fs(KERNEL_DS);
 
-    r = sock_setsockopt(control, SOL_SOCKET, SO_SNDBUF, (void *) &buffsize, sizeof (int));
+    opt = 1;
+
+    r = kernel_setsockopt(control, SOL_SOCKET, SO_REUSEADDR, (char *)&opt, sizeof (opt));
     if (r < 0) {
         DBG("Error setting socket options");
         return r;
@@ -87,18 +87,13 @@ int setup_tcp() {
 
     set_fs(fs);
 
-    if (r < 0) {
-        DBG("Error setting buffsize %d", r);
-        return r;
-    }
-
-    r = control->ops->bind(control,(struct sockaddr*) &saddr,sizeof(saddr));
+    r = kernel_bind(control,(struct sockaddr*) &saddr,sizeof(saddr));
     if (r < 0) {
         DBG("Error binding control socket");
         return r;
     }
 
-    r = control->ops->listen(control,1);
+    r = kernel_listen(control,1);
     if (r) {
         DBG("Error listening on socket");
         return r;
@@ -118,9 +113,9 @@ int setup_tcp() {
     }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)
-    r = accept->ops->accept(control,accept,0,true);
+    r = kernel_accept(control, &accept, 0, true);
 #else
-    r = accept->ops->accept(control,accept,0);
+    r = kernel_accept(control, &accept, 0);
 #endif
 
     if (r < 0) {
@@ -132,15 +127,15 @@ int setup_tcp() {
 }
 
 void cleanup_tcp() {
-    if (accept && accept->ops) {
-        accept->ops->shutdown(accept, 0);
-        accept->ops->release(accept);
+    if (accept) {
+        kernel_sock_shutdown(accept, SHUT_RDWR);
+        sock_release(accept);
         accept = NULL;
     }
 
-    if (control && control->ops) {
-        control->ops->shutdown(control, 0);
-        control->ops->release(control);
+    if (control) {
+        kernel_sock_shutdown(control, SHUT_RDWR);
+        sock_release(control);
         control = NULL;
     }
 }


### PR DESCRIPTION
Add a new option to enable compression using zlib library from the kernel.

I have adjusted the compression level to reduce memory footprint while providing a good speedup. It performs more than 4x in my tests with Android.

This PR also does some code refactor for future improvements and fixes minor bugs. It resolves #31.