### PR TITLE
LINUX 5.8: Replace kernel_setsockopt() with sock_set_reuseaddr()

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -77,6 +77,9 @@ int setup_tcp() {
     fs = get_fs();
     set_fs(KERNEL_DS);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+    sock_set_reuseaddr(control->sk);
+#else
     opt = 1;
 
     r = kernel_setsockopt(control, SOL_SOCKET, SO_REUSEADDR, (char *)&opt, sizeof (opt));
@@ -84,6 +87,7 @@ int setup_tcp() {
         DBG("Error setting socket options");
         return r;
     }
+#endif
 
     set_fs(fs);
 


### PR DESCRIPTION
Linux 5.8-rc1 commit 'net: remove kernel_setsockopt' (5a892ff2facb) retires the
kernel_setsockopt function - replace it with sock_set_reuseaddr().

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>