### PR TITLE
Linux 5.10 fixes

### DIFF
--- a/src/disk.c
+++ b/src/disk.c
@@ -43,12 +43,15 @@ static int dio_write_test(char *path, int oflags)
 }
 
 int setup_disk(char *path, int dio) {
-    mm_segment_t fs;
     int oflags;
     int err;
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,10,0)
+    mm_segment_t fs;
+
     fs = get_fs();
     set_fs(KERNEL_DS);
+#endif
 
     oflags = O_WRONLY | O_CREAT | O_LARGEFILE | O_TRUNC;
 
@@ -62,24 +65,32 @@ int setup_disk(char *path, int dio) {
 
     if (!f || IS_ERR(f)) {
         DBG("Error opening file %ld", PTR_ERR(f));
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,10,0)
         set_fs(fs);
+#endif
         err = (f) ? PTR_ERR(f) : -EIO;
         f = NULL;
         return err;
     }
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,10,0)
     set_fs(fs);
+#endif
 
     return 0;
 }
 
 void cleanup_disk(void) {
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,10,0)
     mm_segment_t fs;
 
     fs = get_fs();
     set_fs(KERNEL_DS);
+#endif
     if(f) filp_close(f, NULL);
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,10,0)
     set_fs(fs);
+#endif
 }
 
 ssize_t write_vaddr_disk(void * v, size_t is) {

--- a/src/disk.c
+++ b/src/disk.c
@@ -83,27 +83,27 @@ void cleanup_disk(void) {
 }
 
 ssize_t write_vaddr_disk(void * v, size_t is) {
-    mm_segment_t fs;
 
     ssize_t s;
     loff_t pos;
-
-    fs = get_fs();
-    set_fs(KERNEL_DS);
 
     pos = f->f_pos;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
     s = kernel_write(f, v, is, &pos);
 #else
+    mm_segment_t fs;
+
+    fs = get_fs();
+    set_fs(KERNEL_DS);
+
     s = vfs_write(f, v, is, &pos);
+    set_fs(fs);
 #endif
 
     if (s == is) {
         f->f_pos = pos;
     }
-
-    set_fs(fs);
 
     return s;
 }


### PR DESCRIPTION
5.10-rc1 completely removed the set_fs()/get_fs() APIs (so the kmod failed to build): fixed, and tested it by dumping the entire memory to a local file.