### PR TITLE
Fix endless loop on PAE kernels with ranges > 4GiB

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -280,7 +280,11 @@ static void write_range(struct resource * res) {
 #endif
         p = pfn_to_page((i) >> PAGE_SHIFT);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,18)
+        is = min((resource_size_t) PAGE_SIZE, (resource_size_t) (res->end - i + 1));
+#else
         is = min((size_t) PAGE_SIZE, (size_t) (res->end - i + 1));
+#endif
 
         if (is < PAGE_SIZE) {
             // We can't map partial pages and


### PR DESCRIPTION
On PAE systems with sufficiently large physical memory ranges, the subtraction result of `res->end - i + 1` can overflow when casted to `size_t`, resulting in is being set to 0 and causing an endless loop.
This can hang or crash the kernel.

See-also: #36
Co-authored-by: @pagabuc 