### PR TITLE
[WIP][RISC-V] Workaround to avoid crashes due to PMP protected memory.  

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,6 +23,10 @@
 obj-m := lime.o
 lime-objs := tcp.o disk.o main.o hash.o deflate.o
 
+ifeq ($(ARCH), riscv)
+	kcflags := "-DLIME_RISCV"
+endif
+
 KVER ?= $(shell uname -r)
 
 KDIR ?= /lib/modules/$(KVER)/build
@@ -32,13 +36,13 @@ PWD := $(shell pwd)
 .PHONY: modules modules_install clean distclean debug
 
 default:
-	$(MAKE) -C $(KDIR) M="$(PWD)" modules
-	strip --strip-unneeded lime.ko
+	KCFLAGS=$(kcflags) $(MAKE) -C $(KDIR) M="$(PWD)" modules
+	$(CROSS_COMPILE)strip --strip-unneeded lime.ko
 	mv lime.ko lime-$(KVER).ko
 
 debug:
-	KCFLAGS="-DLIME_DEBUG" $(MAKE) CONFIG_DEBUG_SG=y -C $(KDIR) M="$(PWD)" modules
-	strip --strip-unneeded lime.ko
+	KCFLAGS="-DLIME_DEBUG $(kcflags)" $(MAKE) CONFIG_DEBUG_SG=y -C $(KDIR) M="$(PWD)" modules
+	$(CROSS_COMPILE)strip --strip-unneeded lime.ko
 	mv lime.ko lime-$(KVER).ko
 
 symbols:
@@ -47,7 +51,7 @@ symbols:
 
 modules:    main.c disk.c tcp.c hash.c lime.h
 	$(MAKE) -C /lib/modules/$(KVER)/build M="$(PWD)" $@
-	strip --strip-unneeded lime.ko
+	$(CROSS_COMPILE)strip --strip-unneeded lime.ko
 
 modules_install:    modules
 	$(MAKE) -C $(KDIR) M="$(PWD)" $@

--- a/src/lime.h
+++ b/src/lime.h
@@ -84,6 +84,32 @@
 #define LIME_SUPPORTS_DEFLATE
 #endif
 
+#ifdef LIME_RISCV
+#define RISCV_LOAD_ACCESS_FAULT 5
+
+#define riscv_test_load_access(v_addr)                                         \
+  ({                                                                           \
+    int __v = 0xdeadbeef;                                                      \
+    __asm__ __volatile__("1:\n"                                                \
+                         "ld t0, 0(%1)\n"                                      \
+                         "2:\n"                                                \
+                         ".section .fixup,\"ax\"\n"                            \
+                         "3:\n"                                                \
+                         "csrr %0, scause\n"                                   \
+                         "j 2b\n"                                              \
+                         ".previous\n" _ASM_EXTABLE(1b, 3b)                    \
+                         : "=r"(__v)                                           \
+                         : "r"(v_addr)                                         \
+                         : "memory");                                          \
+    __v;                                                                       \
+  })
+
+typedef struct {
+  unsigned long long start;
+  unsigned long long end;
+} riscv_pmp_region;
+#endif
+
 //structures
 
 typedef struct {


### PR DESCRIPTION
As described in issue [105](https://github.com/504ensicsLabs/LiME/issues/105) the LiME module crashes under RISC-V when it
encounters a protected memory area through PMP (Physical Memory Protection).

In my workaround, I first test if the memory address is readable by
dereferencing it in a temporary-register. If an exception occurs during this test,
the error value is returned from the _scause_ register. If the exception is a
"load access fault", zero bytes are written to the dump for the memory
page. This prevents the LiME module from crashing and as a small side effect
it is also possible to detect protected memory areas by PMP in S-Mode, since
the corresponding registers _pmpaddr{0..n}_ can only be accessed in M-Mode.