### PR TITLE
[x86][PATCH] Fix Scheduling while atomic issue with kernel_write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 Module.symvers
 modules.order
+*.mod
 *.mod.c
 *.cmd
 .tmp_versions/

--- a/src/disk.c
+++ b/src/disk.c
@@ -103,6 +103,9 @@ ssize_t write_vaddr_disk(void * v, size_t is) {
     s = vfs_write(f, v, is, &pos);
     set_fs(fs);
 #else
+#ifdef CONFIG_SMP
+    preempt_enable(); /* Scheduling while atomic bug temporary fix */
+#endif
     s = kernel_write(f, v, is, &pos);
 #endif
 


### PR DESCRIPTION
On SMP systems the kernel seems to yield "Scheduling while atomic" bug when `kernel_write` is called, at `write_vaddr_disk`, with a complain that preemption was disabled somewhere at `init_module`. Having `preempt_enable` before `kernel_write` seems to fix it, though since I'm not an expert with preemption and scheduling I'm not sure this is the right way to fix that issue, but for now it works as expected.

Lastly, the module build system outputs another file "lime.mod", then "*.mod" is added to `.gitignore`.

**ENV:**
6.0.0-12parrot1-amd64
LiME disk format build
Built and loaded inside a virtual machine