### PR TITLE
[x86] Fix kmap_atomic raises scheduling while atomic bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 Module.symvers
 modules.order
+*.mod
 *.mod.c
 *.cmd
 .tmp_versions/

--- a/src/main.c
+++ b/src/main.c
@@ -301,15 +301,17 @@ static void write_range(struct resource * res) {
              * If we need to compute the digest or compress the output
              * take a snapshot of the page. Otherwise save some cycles.
              */
+#ifdef LIME_USE_KMAP_ATOMIC
             preempt_enable();
+#endif
             if (no_overlap) {
                 copy_page(vpage, v);
                 s = write_vaddr(vpage, is);
             } else {
                 s = write_vaddr(v, is);
             }
-            preempt_disable();
 #ifdef LIME_USE_KMAP_ATOMIC
+            preempt_disable();
             kunmap_atomic(v);
 #else
             kunmap(p);

--- a/src/main.c
+++ b/src/main.c
@@ -301,12 +301,14 @@ static void write_range(struct resource * res) {
              * If we need to compute the digest or compress the output
              * take a snapshot of the page. Otherwise save some cycles.
              */
+            preempt_enable();
             if (no_overlap) {
                 copy_page(vpage, v);
                 s = write_vaddr(vpage, is);
             } else {
                 s = write_vaddr(v, is);
             }
+            preempt_disable();
 #ifdef LIME_USE_KMAP_ATOMIC
             kunmap_atomic(v);
 #else


### PR DESCRIPTION
`kmap_atomic` disables preemption, we have to enable it for an I/O operation, in this case it's `kernel_write` as it causes an interrupt and scheduler work. According to #80 `kmap_atomic` makes the writing faster, and we want to keep it as is.