### PR TITLE
Fix the build process on ARMs

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -98,7 +98,7 @@ int ldigest_update(void *v, size_t is) {
     int ret;
     struct scatterlist sg;
 
-    if (likely(virt_addr_valid((unsigned long) v))) {
+    if (likely(virt_addr_valid(v))) {
         sg_init_one(&sg, (u8 *) v, is);
     } else {
         int nbytes = is;


### PR DESCRIPTION
Description: the virt_addr_valid macro wants a void* argument

This patch was provided by Andreas Beckmann <anbe@debian.org> to Debian project.
See details at https://bugs.debian.org/1100959
