### PR TITLE
Prevent build error after changes in kernel_bind() prototype

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -83,7 +83,11 @@ int setup_tcp() {
     sock_set_reuseaddr(control->sk);
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,19,6)
     r = kernel_bind(control,(struct sockaddr*) &saddr,sizeof(saddr));
+#else
+    r = kernel_bind(control,(struct sockaddr_unsized *) &saddr,sizeof(saddr));
+#endif
     if (r < 0) {
         DBG("Error binding control socket");
         return r;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -83,7 +83,7 @@ int setup_tcp() {
     sock_set_reuseaddr(control->sk);
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,19,6)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,19,0)
     r = kernel_bind(control,(struct sockaddr*) &saddr,sizeof(saddr));
 #else
     r = kernel_bind(control,(struct sockaddr_unsized *) &saddr,sizeof(saddr));


### PR DESCRIPTION
The following error was observed when building the module with gcc version 15.2.0 (Debian 15.2.0-14):

  [...]
  tcp.c: In function ‘setup_tcp’:
  tcp.c:86:29: error: passing argument 2 of ‘kernel_bind’ from incompatible pointer type [-Wincompatible-pointer-types]
     86 |     r = kernel_bind(control,(struct sockaddr*) &saddr,sizeof(saddr));
        |                             ^~~~~~~~~~~~~~~~~~~~~~~~~
        |                             |
        |                             struct sockaddr *
  In file included from /usr/src/linux-headers-6.19.6+deb14+1-common/include/net/scm.h:6,
                   from /usr/src/linux-headers-6.19.6+deb14+1-common/include/linux/netlink.h:9,
                   from /usr/src/linux-headers-6.19.6+deb14+1-common/include/uapi/linux/neighbour.h:6,
                   from /usr/src/linux-headers-6.19.6+deb14+1-common/include/linux/netdevice.h:44,
                   from /usr/src/linux-headers-6.19.6+deb14+1-common/include/net/sock.h:46,
                   from tcp.c:32:
  /usr/src/linux-headers-6.19.6+deb14+1-common/include/linux/net.h:347:63: note: expected ‘struct sockaddr_unsized *’ but argument is of type ‘struct sockaddr *’
    347 | int kernel_bind(struct socket *sock, struct sockaddr_unsized *addr, int addrlen);
        |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
  disk.c:45:5: warning: no previous prototype for ‘setup_disk’ [-Wmissing-prototypes]
  [...]

Likely related to linux 0e50474fa514 ("net: Convert proto_ops bind() callbacks to use sockaddr_unsized")

Build tested only.